### PR TITLE
Start switching to a non-regex based tokenizer

### DIFF
--- a/lib/parse-to-unist.ts
+++ b/lib/parse-to-unist.ts
@@ -3,8 +3,6 @@ import { tokenize } from "./tokenize";
 import { FORMAL_NAMES } from "./formal_names";
 import { Parent } from "unist";
 
-const rTerminator = new RegExp("(\\r|\\n|\\r\\n|\\n\\r)", "g");
-
 function lineToNode({ tag, value, xref_id, pointer }: Line) {
   const formal_name = FORMAL_NAMES[tag];
   const node: Parent = {
@@ -49,18 +47,16 @@ function handleContinued({ tag, value, pointer }: Line, head: Parent) {
  * @param input - GEDCOM data as a string
  * @returns ast
  */
-export function parse(input: string): Parent {
+export function parse(tokens: Token[]): Parent {
   let root: Parent = {
     type: "root",
     children: [],
   };
 
-  const lines = input.split(rTerminator).filter((str) => str.trim());
-
   let stack: Parent[] = [];
   let lastLevel = 0;
 
-  for (const line of lines) {
+  for (const line of tokens) {
     const tokens = tokenize(line);
 
     if (handleContinued(tokens, stack[stack.length - 1])) {

--- a/lib/tokenize.test.ts
+++ b/lib/tokenize.test.ts
@@ -2,54 +2,54 @@ import { test } from "tap";
 import { tokenize } from "./tokenize";
 
 test("parser", (t) => {
-  t.same(tokenize("0 HEAD"), { level: 0, tag: "HEAD" });
+  t.same(tokenize("0"), [{ type: "LEVEL", value: 0 }]);
 
-  t.same(tokenize("  \t 1 NAME Will /Rogers/"), {
-    level: 1,
-    tag: "NAME",
-    value: "Will /Rogers/",
-  });
+  // t.same(tokenize("  \t 1 NAME Will /Rogers/"), {
+  //   level: 1,
+  //   tag: "NAME",
+  //   value: "Will /Rogers/",
+  // });
 
-  t.same(tokenize("  \t 1 SOUR SPACE AFTER "), {
-    level: 1,
-    tag: "SOUR",
-    value: "SPACE AFTER ",
-  });
+  // t.same(tokenize("  \t 1 SOUR SPACE AFTER "), {
+  //   level: 1,
+  //   tag: "SOUR",
+  //   value: "SPACE AFTER ",
+  // });
 
-  t.same(tokenize("12 _USER_DEFINED_TAG X"), {
-    level: 12,
-    tag: "_USER_DEFINED_TAG",
-    value: "X",
-  });
+  // t.same(tokenize("12 _USER_DEFINED_TAG X"), {
+  //   level: 12,
+  //   tag: "_USER_DEFINED_TAG",
+  //   value: "X",
+  // });
 
-  t.same(tokenize("0 @I1@ INDI"), {
-    level: 0,
-    xref_id: "@I1@",
-    tag: "INDI",
-  });
+  // t.same(tokenize("0 @I1@ INDI"), {
+  //   level: 0,
+  //   xref_id: "@I1@",
+  //   tag: "INDI",
+  // });
 
-  t.same(tokenize("1 CHIL @1234@"), {
-    level: 1,
-    tag: "CHIL",
-    pointer: "@1234@",
-  });
+  // t.same(tokenize("1 CHIL @1234@"), {
+  //   level: 1,
+  //   tag: "CHIL",
+  //   pointer: "@1234@",
+  // });
 
-  t.same(tokenize("0 INDI"), {
-    level: 0,
-    tag: "INDI",
-  });
-
-  t.end();
-});
-
-test("parser error conditions", (t) => {
-  t.throws(() => {
-    tokenize("1");
-  });
-
-  t.throws(() => {
-    tokenize("01 INDI");
-  });
+  // t.same(tokenize("0 INDI"), {
+  //   level: 0,
+  //   tag: "INDI",
+  // });
 
   t.end();
 });
+
+// test("parser error conditions", (t) => {
+//   t.throws(() => {
+//     tokenize("1");
+//   });
+//
+//   t.throws(() => {
+//     tokenize("01 INDI");
+//   });
+//
+//   t.end();
+// });

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -18,13 +18,34 @@ const rLineItem = new RegExp(/^(.*)/);
 
 type TagName = keyof typeof FORMAL_NAMES;
 
-export type Line = {
-  level: number;
-  tag: TagName;
-  xref_id?: string;
-  pointer?: string;
-  value?: string;
+// export type Line = {
+//   level: number;
+//   tag: TagName;
+//   xref_id?: string;
+//   pointer?: string;
+//   value?: string;
+// };
+
+export type Pos = {
+  line: number;
+  column: number;
+  offset: number;
 };
+
+export type Token = {
+  type: "level" | "eol";
+  value?: string;
+  start: Pos;
+  end: Pos;
+};
+
+function ws(code: number) {
+  return code === 9 /* `\t` */ || code === 32; /* ` ` */
+}
+
+type TokenType = Token["type"];
+
+const rTerminator = new RegExp("(\\r|\\n|\\r\\n|\\n\\r)", "g");
 
 /**
  * Lowest-level API to parse-gedcom: parses a single line
@@ -35,53 +56,128 @@ export type Line = {
  * @param buf - One line of GEDCOM data as a string
  * @returns a line object.
  */
-export function tokenize(buf: string): Line {
-  function expect(re: RegExp, message: string) {
-    const match = buf.match(re);
-    if (!match) throw new Error(message);
-    buf = buf.substring(match[0].length);
-    return match[1];
+export function tokenize(buffer: string): Token[] {
+  let line = 1;
+  let column = 1;
+  let offset = 0;
+  // GEDCOM supports \n, \r, \r\n, and \n\r, so search for the first.
+  let end = Math.min(buffer.indexOf("\n"), buffer.indexOf("\r"));
+  let start = 0;
+  let value;
+  let eol;
+  const tokens: Token[] = [];
+
+  function add(type: TokenType, value: string) {
+    let start = now();
+
+    offset += value.length;
+    column += value.length;
+
+    // Note that only a final line feed is supported: it’s assumed that
+    // they’ve been split over separate tokens already.
+    if (value.charCodeAt(value.length - 1) === 10 /* `\n` */) {
+      line++;
+      column = 1;
+    }
+
+    let token: Token = {
+      type,
+      start,
+      end: now(),
+    };
+    if (value) token.value = value;
+    tokens.push(token);
   }
 
-  buf = buf.trimStart();
-  let xref_id: string | undefined = undefined;
-  const levelStr = expect(rLevel, "Expected level");
-
-  if (levelStr.length > 2 || (levelStr.length === 2 && levelStr[0] === "0")) {
-    throw new Error(`Invalid level: ${levelStr}`);
+  function now() {
+    return { line: line, column: column, offset: offset };
   }
 
-  const level = parseInt(levelStr);
+  while (end > -1) {
+    value = buffer.slice(start, end);
+    if (value.charCodeAt(value.length - 1) === 13 /* `\r` */) {
+      value = value.slice(0, -1);
+      eol = "\r\n";
+    } else if (value.charCodeAt(value.length - 1) === 13 /* `\r` */) {
+      // TODO: fix for this case
+      value = value.slice(0, -1);
+      eol = "\n\r";
+    } else {
+      eol = "\n";
+    }
 
-  expect(rDelim, "Expected delimiter after level");
+    parseLine(value);
+    add("eol", eol);
 
-  const xref = buf.match(rPointer);
-  if (xref) {
-    xref_id = xref[0];
-    buf = buf.substring(xref[0].length);
-    expect(rDelim, "Expected delimiter after pointer");
+    start = end + 1;
+    end = buffer.indexOf("\n", start);
   }
 
-  const tag = expect(rTag, "Expected tag") as TagName;
+  function parseLine(value: string) {
+    let code = value.charCodeAt(0);
+    let start;
+    let index = 0;
 
-  let line: Line = {
-    level,
-    tag,
-  };
+    // Allow any amount of whitespace at the beginning of a line
+    while (ws(value.charCodeAt(index))) index++;
 
-  if (xref_id) line.xref_id = xref_id;
+    code = value.charCodeAt(index);
 
-  const delim = buf.match(rDelim);
-  if (delim) {
-    buf = buf.substring(delim[0].length);
-    const pointer_match = buf.match(rPointer);
-    const value_match = buf.match(rLineItem);
-    if (pointer_match) {
-      line.pointer = pointer_match[0];
-    } else if (value_match) {
-      line.value = value_match[1];
+    // 0-9
+    if (code >= 48 && code <= 59) {
+      let secondDigit = value.charCodeAt(index + 1);
+      const hasSecondDigit = (secondDigit >= 48 && secondDigit <= 59)
+      add('level', value.slice(index, hasSecondDigit 
     }
   }
 
-  return line;
+  // input.split(rTerminator);
+  // function expect(re: RegExp, message: string) {
+  //   const match = buf.match(re);
+  //   if (!match) throw new Error(message);
+  //   buf = buf.substring(match[0].length);
+  //   return match[1];
+  // }
+
+  // buf = buf.trimStart();
+  // let xref_id: string | undefined = undefined;
+  // const levelStr = expect(rLevel, "Expected level");
+
+  // if (levelStr.length > 2 || (levelStr.length === 2 && levelStr[0] === "0")) {
+  //   throw new Error(`Invalid level: ${levelStr}`);
+  // }
+
+  // const level = parseInt(levelStr);
+
+  // expect(rDelim, "Expected delimiter after level");
+
+  // const xref = buf.match(rPointer);
+  // if (xref) {
+  //   xref_id = xref[0];
+  //   buf = buf.substring(xref[0].length);
+  //   expect(rDelim, "Expected delimiter after pointer");
+  // }
+
+  // const tag = expect(rTag, "Expected tag") as TagName;
+
+  // let line: Line = {
+  //   level,
+  //   tag,
+  // };
+
+  // if (xref_id) line.xref_id = xref_id;
+
+  // const delim = buf.match(rDelim);
+  // if (delim) {
+  //   buf = buf.substring(delim[0].length);
+  //   const pointer_match = buf.match(rPointer);
+  //   const value_match = buf.match(rLineItem);
+  //   if (pointer_match) {
+  //     line.pointer = pointer_match[0];
+  //   } else if (value_match) {
+  //     line.value = value_match[1];
+  //   }
+  // }
+
+  return tokens;
 }


### PR DESCRIPTION
This will eventually resolve the parser issues: add location information to tokens and make the parser more efficient, opening up an opportunity for the parser to do streams. Taking heavy inspiration from [discuri](https://github.com/wooorm/dioscuri/blob/main/lib/parser.mjs) as a parser.

This is very early on, and I need a fresh brain to make much more progress on it.