### PR TITLE
allow hyphen in xref_id

### DIFF
--- a/lib/tokenize.test.ts
+++ b/lib/tokenize.test.ts
@@ -28,6 +28,12 @@ test("parser", (t) => {
     tag: "INDI",
   });
 
+  t.same(tokenize("0 @I-1WITHHYPHEN@ INDI"), {
+    level: 0,
+    xref_id: "@I-1WITHHYPHEN@",
+    tag: "INDI",
+  });
+
   t.same(tokenize("1 CHIL @1234@"), {
     level: 1,
     tag: "CHIL",

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -11,7 +11,7 @@ const cHash = "#";
 const cNonAt = `${cAlpha}${cDigit}${cDelim}${cHash}`;
 const cPointerChar = cNonAt;
 const rPointer = new RegExp(
-  `^${cAt}([${cAlphanum}])([${cPointerChar}])*${cAt}`
+  `^${cAt}([${cAlphanum}])([${cPointerChar}\\-])*${cAt}`
 );
 const rTag = new RegExp(`^(_?[${cAlphanum}]+)`);
 const rLineItem = new RegExp(/^(.*)/);


### PR DESCRIPTION
The xref_ids in the gedcom files I am working with have hyphens.

Example of input line: `0 @I-1234567890@ INDI`

Otherwise, this worked flawlessly! Thank you!