### PR TITLE
Improve error handling during parsing

### DIFF
--- a/lib/parse-to-unist.ts
+++ b/lib/parse-to-unist.ts
@@ -23,9 +23,9 @@ function lineToNode({ tag, value, xref_id, pointer }: Line) {
   return node;
 }
 
-function handleContinued({ tag, value, pointer }: Line, head: Parent) {
+function handleContinued({ tag, value, pointer }: Line, head: Parent, lineNumber?: number) {
   if (!(tag === "CONC" || tag === "CONT")) return false;
-  if (pointer) throw new Error("Cannot concatenate a pointer");
+  if (pointer) throw new Error(lineNumber ? `Cannot concatenate a pointer (CONC/CONT cannot have a pointer value) at line ${lineNumber}` : "Cannot concatenate a pointer (CONC/CONT cannot have a pointer value)");
   // If this is a NOTE tag, it may not have any text at the beginning.
   if (head.data) {
     if (!head.data.value) head.data.value = "";
@@ -63,10 +63,11 @@ export function parse(input: string): Parent {
   let stack: Parent[] = [];
   let lastLevel = 0;
 
-  for (const line of lines) {
-    const tokens = tokenize(line);
+  for (let i = 0; i < lines.length; i++) {
+    const lineNumber = i + 1;
+    const tokens = tokenize(lines[i], lineNumber);
 
-    if (handleContinued(tokens, stack[stack.length - 1])) {
+    if (handleContinued(tokens, stack[stack.length - 1], lineNumber)) {
       continue;
     }
 
@@ -83,9 +84,7 @@ export function parse(input: string): Parent {
       stack[stack.length - 1].children.push(node);
       stack.push(node);
     } else {
-      throw new Error(
-        `Illegal nesting: transition from ${lastLevel} to ${level}`,
-      );
+      throw new Error( `Illegal nesting at line ${lineNumber}: transition from level ${lastLevel} to ${level}`, );
     }
     lastLevel = level;
   }

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -35,10 +35,10 @@ export type Line = {
  * @param buf - One line of GEDCOM data as a string
  * @returns a line object.
  */
-export function tokenize(buf: string): Line {
+export function tokenize(buf: string, lineNumber?: number): Line {
   function expect(re: RegExp, message: string) {
     const match = buf.match(re);
-    if (!match) throw new Error(message);
+    if (!match) throw new Error(lineNumber ? `${message} at line ${lineNumber}` : message);
     buf = buf.substring(match[0].length);
     return match[1];
   }
@@ -48,7 +48,7 @@ export function tokenize(buf: string): Line {
   const levelStr = expect(rLevel, "Expected level");
 
   if (levelStr.length > 2 || (levelStr.length === 2 && levelStr[0] === "0")) {
-    throw new Error(`Invalid level: ${levelStr}`);
+    throw new Error(lineNumber ? `Invalid level: ${levelStr} at line ${lineNumber}` : `Invalid level: ${levelStr}`);
   }
 
   const level = Number.parseInt(levelStr);


### PR DESCRIPTION
When parsing large gedcom files with errors, it is essential to get an indication about where in the source file the error is. This is an attempt to improve this limitation of  this component.