### PR TITLE
Allow all text in plain text fields

### DIFF
--- a/lib/parse-to-unist.test.ts
+++ b/lib/parse-to-unist.test.ts
@@ -287,13 +287,15 @@ test("parser - concatenation", () => {
   );
 });
 
-test("parser - concatenation", () => {
-  expect(() => {
+test("parser - concatenation with @ symbols", () => {
+  expect(
     parse(`
 0 SOUR Waters, Henry F., Genealogical Gleanings in England: Abstracts of W
 1 CONC ills Relating to Early American Families. 2 vols., reprint 1901, 190
-1 CONC @123@`).children[0].data?.value;
-  }).toThrow();
+1 CONC @123@`).children[0].data?.value,
+  ).toEqual(
+    "Waters, Henry F., Genealogical Gleanings in England: Abstracts of Wills Relating to Early American Families. 2 vols., reprint 1901, 190@123@",
+  );
 });
 
 test("parser - error, too large a jump", (t) => {

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -71,7 +71,7 @@ export function tokenize(buf: string, lineNumber: number): Line {
 
   if (xref_id) line.xref_id = xref_id;
 
-  const plaintext = (tag === "CONC" || tag === "CONT" || tag === "NOTE");
+  const plaintext = tag === "CONC" || tag === "CONT" || tag === "NOTE";
   const delim = buf.match(rDelim);
   if (delim) {
     buf = buf.substring(delim[0].length);

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -71,8 +71,9 @@ export function tokenize(buf: string, lineNumber: number): Line {
 
   if (xref_id) line.xref_id = xref_id;
 
+  const plaintext = (tag === "CONC" || tag === "CONT" || tag === "NOTE");
   const delim = buf.match(rDelim);
-  if (delim) {
+  if (delim && !plaintext) {
     buf = buf.substring(delim[0].length);
     const pointer_match = buf.match(rPointer);
     const value_match = buf.match(rLineItem);

--- a/lib/tokenize.ts
+++ b/lib/tokenize.ts
@@ -73,9 +73,9 @@ export function tokenize(buf: string, lineNumber: number): Line {
 
   const plaintext = (tag === "CONC" || tag === "CONT" || tag === "NOTE");
   const delim = buf.match(rDelim);
-  if (delim && !plaintext) {
+  if (delim) {
     buf = buf.substring(delim[0].length);
-    const pointer_match = buf.match(rPointer);
+    const pointer_match = !plaintext && buf.match(rPointer);
     const value_match = buf.match(rLineItem);
     if (pointer_match) {
       line.pointer = pointer_match[0];


### PR DESCRIPTION
The gedcom parser did not allow GEDCOM links in plain text fields. This has now been fixed.